### PR TITLE
Fix bug that prevent tracts from displaying on map

### DIFF
--- a/frontend/src/components/Home.js
+++ b/frontend/src/components/Home.js
@@ -52,7 +52,7 @@ class Home extends React.Component {
         const responseRates = data.data.result.response_rates;
         var tractData = {};
         responseRates.forEach(response_rate => {
-          tractData[response_rate.tract_id] = response_rate.rate;
+          tractData[response_rate.tract_id] = response_rate.rate[0];
         });
         this.setState({
           tractData: tractData


### PR DESCRIPTION
Response rates that backend returns is a tuple, so when preprocessing that data, the front end needs to select the rate from the tuple.