### PR TITLE
Renders tracts after map has finished loading

### DIFF
--- a/frontend/src/components/Home.js
+++ b/frontend/src/components/Home.js
@@ -42,6 +42,7 @@ class Home extends React.Component {
     };
     this.map = null;
     this.tractCache = {};
+    this.renderCount = 0; 
   }
 
   getCensusMBRColor = response_rate => {
@@ -98,13 +99,16 @@ class Home extends React.Component {
     });
 
     this.map.on("moveend", () => {
-      const zoom = this.map.getZoom().toFixed(2);
-      if (zoom > MIN_TRACT_ZOOM) {
-        let tractIDs = this.getRenderedTracts();
-        if (tractIDs.length > 0) {
-          this.updateRenderedTracts(tractIDs);
+      this.map.once("idle", () => {
+        const zoom = this.map.getZoom().toFixed(2);
+        if (zoom > MIN_TRACT_ZOOM) {
+          let tractIDs = this.getRenderedTracts();
+          console.log(tractIDs);
+          if (tractIDs.length > 0) {
+            this.updateRenderedTracts(tractIDs);
+          }
         }
-      }
+      });
     });
 
     this.map.on("click", e => {
@@ -214,6 +218,8 @@ class Home extends React.Component {
     if (tractsToRequest.length === 0) {
       this.renderFromCache(tractIds);
     } else {
+      this.renderCount += 1;
+      const currentCount = this.renderCount;
       getBatchResponseByTractIDAndYear(tractsToRequest, "2010").then(
         response => {
           const responseRates = response.data.result.response_rates;
@@ -228,7 +234,9 @@ class Home extends React.Component {
             }
           }
 
-          this.renderFromCache(tractIds);
+          if (currentCount == this.renderCount) {
+            this.renderFromCache(tractIds);
+          }
         }
       );
     }

--- a/frontend/src/components/Home.js
+++ b/frontend/src/components/Home.js
@@ -42,7 +42,7 @@ class Home extends React.Component {
     };
     this.map = null;
     this.tractCache = {};
-    this.renderCount = 0; 
+    this.renderCount = 0;
   }
 
   getCensusMBRColor = response_rate => {
@@ -103,7 +103,6 @@ class Home extends React.Component {
         const zoom = this.map.getZoom().toFixed(2);
         if (zoom > MIN_TRACT_ZOOM) {
           let tractIDs = this.getRenderedTracts();
-          console.log(tractIDs);
           if (tractIDs.length > 0) {
             this.updateRenderedTracts(tractIDs);
           }


### PR DESCRIPTION
The problem this PR fixes is when a user zooms in quickly, not letting the map to render the lower layers. As a result, when the app tries to query which tracts are displayed, it receives zero tracts. Now, the app will wait until the map had finished rendering all layers (the "idle" event), before rendering tracts.